### PR TITLE
New tensor product, fixes

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -3,6 +3,31 @@ name: Publish on PyPi
 on: push
 
 jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up docker image
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: >-
+        python -m
+        pip install
+        -r requirements.txt
+        --user
+    - name: Install pytest
+      run: >-
+        python -m
+        pip install
+        pytest
+        --user
+    - name: Run tests
+      run: >-
+        python -m pytest tests/
+
   build-publish:
     name: Build and publish
     runs-on: ubuntu-latest

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -1,4 +1,4 @@
-name: Publish on PyPi
+name: Tests/Publish on PyPi
 
 on: push
 

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -1,4 +1,4 @@
-name: Tests/Publish on PyPi
+name: Build
 
 on: push
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # experiments
 *.npy
 wandb/
-nohup.out
+*.out
 datasets/
 
 # dev

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [ --profile, black ]

--- a/.pylintrc
+++ b/.pylintrc
@@ -60,6 +60,7 @@ disable=C0114, # module docstring
         W0108, # unnecessary lambda
         W0621, # redifining from outer scope
         C0103, # bad function names
+        C0415, # import outside toplevel
         abstract-method,
         apply-builtin,
         arguments-differ,

--- a/.pylintrc
+++ b/.pylintrc
@@ -61,6 +61,7 @@ disable=C0114, # module docstring
         W0621, # redifining from outer scope
         C0103, # bad function names
         C0415, # import outside toplevel
+        W0212, # protected access
         abstract-method,
         apply-builtin,
         arguments-differ,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Steerable E(3) GNN in jax
 Reimplementation of [SEGNN](https://arxiv.org/abs/2110.02905) in jax. Original work by Johannes Brandstetter, Rob Hesselink, Elise van der Pol, Erik Bekkers and Max Welling.
 
+## Why jax?
+**40-50% faster** inference and training compared to the [original torch implementation](https://github.com/RobDHess/Steerable-E3-GNN). Also JAX-MD.
+
 ## Installation
 ```
 python -m pip install segnn-jax
@@ -19,9 +22,12 @@ pip install --upgrade "jax[cuda]==0.4.1" -f https://storage.googleapis.com/jax-r
 
 ## Validation
 N-body (charged and gravity) and QM9 datasets are included for completeness from the original paper.
-The implementation is validated on all three of them, getting close results and considerably faster runtimes.
 
 ### Results
+Charged is on 5 bodies, gravity on 100 bodies. QM9 has graphs of variable sizes, so in jax samples are padded to the maximum size. Loss is MSE for Charged and Gravity and MAE for QM9.
+
+Times are remeasured on Quadro RTX 4000, __model only__ on batches of 100 graphs, in (global) single precision.
+
 <table>
   <tr>
     <td></td>
@@ -30,36 +36,36 @@ The implementation is validated on all three of them, getting close results and 
   </tr>
   <tr>
     <td></td>
-    <td>MSE</td>
-    <td>Inference [ms]*</td>
-    <td>MSE</td>
+    <td>Loss</td>
+    <td>Inference [ms]</td>
+    <td>Loss</td>
     <td>Inference [ms]</td>
   </tr>
   <tr>
     <td> <code>charged (position)</code> </td>
     <td>.0043</td>
-    <td>40.76</td>
-    <td>.0047</td>
-    <td><b>28.67</td>
+    <td>21.22</td>
+    <td>.0045</td>
+    <td>4.47</td>
   </tr>
   <tr>
     <td><code>gravity (position)</code> </td>
     <td>.265</td>
-    <td>392.20</td>
-    <td>.28</td>
-    <td><b>240.34</td>
+    <td>60.55</td>
+    <td>.264</td>
+    <td>41.72</td>
   </tr>
   <tr>
     <td> <code>QM9 (alpha)</code> </td>
-    <td>.06</td>
-    <td>159.17</td>
-    <td></td>
-    <td>109.58**</td>
+    <td>.075*</td>
+    <td>82.53</td>
+    <td>.098</td>
+    <td>105.98**</td>
   </tr>
 </table>
-* remeasured (Quadro RTX 4000), batch of 100 graphs, single precision
+* rerun
 
-** padded
+** padded (naive)
 
 ### Validation install
 
@@ -90,12 +96,12 @@ python3 -u generate_dataset.py --simulation=gravity --n-balls=100
 ### Usage
 #### N-body (charged)
 ```
-python main.py --dataset=charged --epochs=200 --max-samples=3000 --lmax-hidden=1 --lmax-attributes=1 --layers=4 --units=64 --norm=none --batch-size=100 --lr=5e-4 --weight-decay=1e-8
+python main.py --dataset=charged --epochs=200 --max-samples=3000 --lmax-hidden=1 --lmax-attributes=1 --layers=4 --units=64 --norm=none --batch-size=100 --lr=5e-3 --weight-decay=1e-12
 ```
 
 #### N-body (gravity)
 ```
-python main.py --dataset=gravity --epochs=100 --target=pos --max-samples=10000 --lmax-hidden=1 --lmax-attributes=1 --layers=4 --units=64 --norm=none --batch-size=100 --lr=1e-4 --weight-decay=1e-8 --neighbours=5 --n-bodies=100
+python main.py --dataset=gravity --epochs=100 --target=pos --max-samples=10000 --lmax-hidden=1 --lmax-attributes=1 --layers=4 --units=64 --norm=none --batch-size=100 --lr=5e-3 --weight-decay=1e-12 --neighbours=5 --n-bodies=100
 ```
 
 #### QM9
@@ -108,4 +114,4 @@ python main.py --dataset=qm9 --epochs=1000 --target=alpha --lmax-hidden=2 --lmax
 
 ## Acknowledgments
 - [e3nn_jax](https://github.com/e3nn/e3nn-jax) made this reimplementation possible.
-- [Artur Toshev](https://github.com/arturtoshev) and [Johannes Brandsetter](https://github.com/brandstetter-johannes), for supporting developement.
+- [Artur Toshev](https://github.com/arturtoshev) and [Johannes Brandsetter](https://github.com/brandstetter-johannes), for support.

--- a/experiments/nbody/data/generate_dataset.py
+++ b/experiments/nbody/data/generate_dataset.py
@@ -95,7 +95,6 @@ def generate_dataset(num_sims, length, sample_freq):
 
 
 if __name__ == "__main__":
-
     print("Generating {} training simulations".format(args.num_train))
     loc_train, vel_train, edges_train, charges_train = generate_dataset(
         args.num_train, args.length, args.sample_freq

--- a/experiments/nbody/data/generate_dataset.py
+++ b/experiments/nbody/data/generate_dataset.py
@@ -1,8 +1,8 @@
 """
 Generate charged and gravity datasets.
 
-charged: python3 generate_dataset.py --simulation=charged --num-train=10000 --seed=43
-gravity: python3 generate_dataset.py --simulation=gravity --num-train=10000 --seed=43 --n-balls=100
+charged: python3 generate_dataset.py --simulation=charged --num-train=10000
+gravity: python3 generate_dataset.py --simulation=gravity --num-train=10000 --n-balls=100
 """
 import argparse
 import time

--- a/experiments/nbody/data/synthetic_sim.py
+++ b/experiments/nbody/data/synthetic_sim.py
@@ -42,10 +42,8 @@ class ChargedParticlesSim(object):
         return dist
 
     def _energy(self, loc, vel, edges):
-
         # disables division by zero warning, since I fix it with fill_diagonal
         with np.errstate(divide="ignore"):
-
             K = 0.5 * (vel**2).sum()
             U = 0
             for i in range(loc.shape[1]):

--- a/experiments/nbody/utils.py
+++ b/experiments/nbody/utils.py
@@ -1,8 +1,8 @@
 from typing import Callable, List, Optional, Tuple
 
 import e3nn_jax as e3nn
-import jax.numpy as jnp
 import jax
+import jax.numpy as jnp
 import jax.tree_util as tree
 import numpy as np
 import torch

--- a/experiments/nbody/utils.py
+++ b/experiments/nbody/utils.py
@@ -213,7 +213,7 @@ def setup_nbody_data(args) -> Tuple[DataLoader, DataLoader, DataLoader, Callable
     loader_train = DataLoader(
         dataset_train,
         batch_size=args.batch_size,
-        shuffle=False,
+        shuffle=True,
         drop_last=False,
         collate_fn=numpy_collate,
     )
@@ -221,14 +221,14 @@ def setup_nbody_data(args) -> Tuple[DataLoader, DataLoader, DataLoader, Callable
         dataset_val,
         batch_size=args.batch_size,
         shuffle=False,
-        drop_last=False,
+        drop_last=True,
         collate_fn=numpy_collate,
     )
     loader_test = DataLoader(
         dataset_test,
         batch_size=args.batch_size,
         shuffle=False,
-        drop_last=False,
+        drop_last=True,
         collate_fn=numpy_collate,
     )
 

--- a/experiments/nbody/utils.py
+++ b/experiments/nbody/utils.py
@@ -30,7 +30,6 @@ def O3Transform(
         vel: jnp.ndarray,
         charges: jnp.ndarray,
     ) -> SteerableGraphsTuple:
-
         graph = st_graph.graph
         prod_charges = charges[graph.senders] * charges[graph.receivers]
         rel_pos = loc[graph.senders] - loc[graph.receivers]
@@ -111,7 +110,6 @@ def NbodyGraphTransform(
         ).T
 
     def _to_steerable_graph(data: List) -> Tuple[SteerableGraphsTuple, jnp.ndarray]:
-
         loc, vel, _, q, targets = data
 
         cur_batch = int(loc.shape[0] / n_nodes)

--- a/experiments/nbody/utils.py
+++ b/experiments/nbody/utils.py
@@ -92,7 +92,7 @@ def NbodyGraphTransform(
     dataset_name: str,
     n_nodes: int,
     batch_size: int,
-    neighbours: Optional[int] = 0,
+    neighbours: Optional[int] = 6,
     relative_target: bool = False,
 ) -> Callable:
     """
@@ -124,7 +124,7 @@ def NbodyGraphTransform(
             batch = batch.repeat_interleave(n_nodes).long()
             edge_indices = knn_graph(torch.from_numpy(np.array(loc)), neighbours, batch)
             # switched by default
-            senders, receivers = jnp.array(edge_indices[1]), jnp.array(edge_indices[0])
+            senders, receivers = jnp.array(edge_indices[0]), jnp.array(edge_indices[1])
 
         st_graph = SteerableGraphsTuple(
             graph=GraphsTuple(
@@ -216,21 +216,21 @@ def setup_nbody_data(args) -> Tuple[DataLoader, DataLoader, DataLoader, Callable
         dataset_train,
         batch_size=args.batch_size,
         shuffle=True,
-        drop_last=False,
+        drop_last=True,
         collate_fn=numpy_collate,
     )
     loader_val = DataLoader(
         dataset_val,
         batch_size=args.batch_size,
         shuffle=False,
-        drop_last=True,
+        drop_last=False,
         collate_fn=numpy_collate,
     )
     loader_test = DataLoader(
         dataset_test,
         batch_size=args.batch_size,
         shuffle=False,
-        drop_last=True,
+        drop_last=False,
         collate_fn=numpy_collate,
     )
 

--- a/experiments/nbody/utils.py
+++ b/experiments/nbody/utils.py
@@ -2,6 +2,7 @@ from typing import Callable, List, Optional, Tuple
 
 import e3nn_jax as e3nn
 import jax.numpy as jnp
+import jax
 import jax.tree_util as tree
 import numpy as np
 import torch
@@ -24,6 +25,7 @@ def O3Transform(
     """
     attribute_irreps = e3nn.Irreps.spherical_harmonics(lmax_attributes)
 
+    @jax.jit
     def _o3_transform(
         st_graph: SteerableGraphsTuple,
         loc: jnp.ndarray,
@@ -99,7 +101,7 @@ def NbodyGraphTransform(
 
     if dataset_name == "charged":
         # charged system is a connected graph
-        full_edge_indices = np.array(
+        full_edge_indices = jnp.array(
             [
                 (i + n_nodes * b, j + n_nodes * b)
                 for b in range(batch_size)

--- a/experiments/qm9/utils.py
+++ b/experiments/qm9/utils.py
@@ -26,14 +26,16 @@ def QM9GraphTransform(
     attribute_irreps = e3nn.Irreps.spherical_harmonics(lmax_attributes)
 
     def _to_steerable_graph(data: Data) -> Tuple[SteerableGraphsTuple, jnp.array]:
+        ptr = jnp.array(data.ptr)
+        senders = jnp.array(data.edge_index[0])
+        receivers = jnp.array(data.edge_index[1])
         graph = jraph.GraphsTuple(
             nodes=e3nn.IrrepsArray(node_features_irreps, jnp.array(data.x)),
             edges=None,
-            senders=jnp.array(data.edge_index[0]),
-            receivers=jnp.array(data.edge_index[1]),
-            n_node=jnp.diff(jnp.array(data.ptr)),
-            # n_edge is not used anywhere by segnn, but is neded for padding
-            n_edge=jnp.array([jnp.array(data.edge_index[1]).shape[0]]),
+            senders=senders,
+            receivers=receivers,
+            n_node=jnp.diff(ptr),
+            n_edge=jnp.diff(jnp.sum(senders[:, jnp.newaxis] < ptr, axis=0)),
             globals=None,
         )
         # pad for jax static shapes

--- a/experiments/qm9/utils.py
+++ b/experiments/qm9/utils.py
@@ -45,19 +45,27 @@ def QM9GraphTransform(
             n_edge=max_batch_edges + 1,
             n_graph=graph.n_node.shape[0] + 1,
         )
+
+        node_attributes = e3nn.IrrepsArray(
+            attribute_irreps, jnp.pad(jnp.array(data.node_attr), node_attr_pad)
+        )
+        node_attributes.array = node_attributes.array.at[:, 0].set(1.0)
+
+        additional_message_features = e3nn.IrrepsArray(
+            edge_features_irreps,
+            jnp.pad(jnp.array(data.additional_message_features), edge_attr_pad),
+        )
+        edge_attributes = e3nn.IrrepsArray(
+            attribute_irreps, jnp.pad(jnp.array(data.edge_attr), edge_attr_pad)
+        )
+
         st_graph = SteerableGraphsTuple(
             graph=graph,
-            node_attributes=e3nn.IrrepsArray(
-                attribute_irreps, jnp.pad(jnp.array(data.node_attr), node_attr_pad)
-            ),
-            edge_attributes=e3nn.IrrepsArray(
-                attribute_irreps, jnp.pad(jnp.array(data.edge_attr), edge_attr_pad)
-            ),
-            additional_message_features=e3nn.IrrepsArray(
-                edge_features_irreps,
-                jnp.pad(jnp.array(data.additional_message_features), edge_attr_pad),
-            ),
+            node_attributes=node_attributes,
+            edge_attributes=edge_attributes,
+            additional_message_features=additional_message_features,
         )
+
         # pad targets
         target = jnp.append(jnp.array(data.y), 0)
         return st_graph, target

--- a/main.py
+++ b/main.py
@@ -70,16 +70,16 @@ def mse(
 def evaluate(
     loader, params, segnn_state, graph_transform, loss_fn
 ) -> Tuple[float, float]:
-    eval_loss = []
-    eval_times = []
+    eval_loss = 0.0
+    eval_times = 0.0
     for data in loader:
         graph, target = graph_transform(data)
         eval_start = time.perf_counter_ns()
         loss, _ = jax.lax.stop_gradient(loss_fn(params, segnn_state, graph, target))
-        eval_loss.append(loss)
-        eval_times.append((time.perf_counter_ns() - eval_start) / 1e6)
+        eval_loss += loss
+        eval_times += (time.perf_counter_ns() - eval_start) / 1e6
 
-    return sum(eval_times) / len(eval_times), sum(eval_loss) / len(eval_loss)
+    return eval_times / len(loader), eval_loss / len(loader)
 
 
 def train(

--- a/main.py
+++ b/main.py
@@ -90,9 +90,10 @@ def train(
     params, segnn_state = segnn.init(key, init_graph)
 
     print(
-        f"Starting {args.epochs} epochs on {args.dataset} with {hk.data_structures.tree_size(params)} parameters."
+        f"Starting {args.epochs} epochs on {args.dataset} "
+        f"with {hk.data_structures.tree_size(params)} parameters."
+        "Jitting..."
     )
-    print("Jitting...")
 
     total_steps = args.epochs * len(loader_train)
 

--- a/main.py
+++ b/main.py
@@ -174,6 +174,8 @@ def train(
         )
         test_loss += loss
     test_loss /= len(loader_test)
+    # ignore compilation time
+    avg_time = avg_time[2:]
     avg_time = sum(avg_time) / len(avg_time)
     if args.wandb:
         wandb.log({"test_loss": float(test_loss), "avg_eval_time": float(avg_time)})

--- a/main.py
+++ b/main.py
@@ -3,17 +3,16 @@ import time
 from functools import partial
 from typing import Tuple, Union
 
-import torch
 import e3nn_jax as e3nn
 import haiku as hk
 import jax
 import jax.numpy as jnp
 import optax
+import torch
 import wandb
 
 from experiments import setup_datasets
 from segnn_jax import SEGNN, SteerableGraphsTuple, weight_balanced_irreps
-
 
 key = jax.random.PRNGKey(0)
 torch.manual_seed(0)
@@ -68,7 +67,9 @@ def mse(
         return (jnp.power(pred - target, 2)).mean(), state
 
 
-def eval(loader, params, segnn_state, graph_transform, loss_fn) -> Tuple[float, float]:
+def evaluate(
+    loader, params, segnn_state, graph_transform, loss_fn
+) -> Tuple[float, float]:
     eval_loss = []
     eval_times = []
     for data in loader:
@@ -119,7 +120,7 @@ def train(
         target_mean, target_mad = 0, 1
         loss_fn = mse
 
-    eval_fn = partial(eval, graph_transform=graph_transform, loss_fn=loss_fn)
+    eval_fn = partial(evaluate, graph_transform=graph_transform, loss_fn=loss_fn)
 
     @jax.jit
     def update(

--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ def train(
 
     print(
         f"Starting {args.epochs} epochs on {args.dataset} "
-        f"with {hk.data_structures.tree_size(params)} parameters."
+        f"with {hk.data_structures.tree_size(params)} parameters.\n"
         "Jitting..."
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 dm-haiku==0.0.9
-e3nn-jax==0.12.0
+e3nn-jax==0.17.0
 jax[cuda]==0.4.1
 jraph==0.0.6.dev0
 numpy>=1.23.4

--- a/segnn_jax/__init__.py
+++ b/segnn_jax/__init__.py
@@ -1,4 +1,4 @@
-from .blocks import O3TensorProduct, O3TensorProductGate
+from .blocks import O3TensorProduct, O3TensorProductGate, O3TensorProductLegacy
 from .graph_utils import SteerableGraphsTuple
 from .irreps_computer import balanced_irreps, weight_balanced_irreps
 from .segnn import SEGNN, SEGNNLayer
@@ -7,6 +7,7 @@ __all__ = [
     "SEGNN",
     "SEGNNLayer",
     "O3TensorProduct",
+    "O3TensorProductLegacy",
     "O3TensorProductGate",
     "weight_balanced_irreps",
     "balanced_irreps",

--- a/segnn_jax/__init__.py
+++ b/segnn_jax/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "SteerableGraphsTuple",
 ]
 
-__version__ = "0.3"
+__version__ = "0.5"

--- a/segnn_jax/blocks.py
+++ b/segnn_jax/blocks.py
@@ -135,7 +135,7 @@ class O3TensorProduct(hk.Module):
             The output to the weighted tensor product (IrrepsArray).
         """
 
-        if y is None:
+        if not y:
             y = e3nn.IrrepsArray("1x0e", jnp.ones((1, 1)))
 
         if x.irreps.lmax == 0 and y.irreps.lmax == 0 and self.output_irreps.lmax > 0:
@@ -189,6 +189,10 @@ def O3TensorProductLegacy(
         A function that returns the output to the weighted tensor product.
     """
 
+
+    if not right_irreps:
+        right_irreps = e3nn.Irreps("1x0e")
+
     if not init_fn:
         init_fn = uniform_init
 
@@ -214,7 +218,7 @@ def O3TensorProductLegacy(
             The output to the weighted tensor product (IrrepsArray).
         """
 
-        if y is None:
+        if not y:
             y = e3nn.IrrepsArray("1x0e", jnp.ones((1, 1)))
 
         if x.irreps.lmax == 0 and y.irreps.lmax == 0 and output_irreps.lmax > 0:
@@ -278,9 +282,9 @@ def O3TensorProductGate(
         name=name,
         init_fn=init_fn,
     )
-    if scalar_activation is None:
+    if not scalar_activation:
         scalar_activation = jax.nn.silu
-    if gate_activation is None:
+    if not gate_activation:
         gate_activation = jax.nn.sigmoid
 
     def _gated_tensor_product(

--- a/segnn_jax/blocks.py
+++ b/segnn_jax/blocks.py
@@ -11,7 +11,7 @@ from .config import config
 from .graph_utils import SteerableGraphsTuple
 
 InitFn = Callable[[str, Tuple[int, ...], float, Any], jnp.ndarray]
-TensorProductFn = Callable[[e3nn.IrrepsArray, e3nn.IrrepsArray], e3nn.IrrepsArray]
+TensorProductFn = Callable[[e3nn.IrrepsArray, Optional[e3nn.IrrepsArray]], e3nn.IrrepsArray]
 
 
 def uniform_init(
@@ -133,7 +133,7 @@ class O3TensorProduct(hk.Module):
             The output to the weighted tensor product (IrrepsArray).
         """
 
-        if not y:
+        if y is None:
             y = e3nn.IrrepsArray("1x0e", jnp.ones((1, 1)))
 
         if x.irreps.lmax == 0 and y.irreps.lmax == 0 and self.output_irreps.lmax > 0:
@@ -199,7 +199,7 @@ def O3TensorProductLegacy(
         path_normalization=path_normalization,
     )
 
-    def _tensor_product(x: e3nn.IrrepsArray, y: e3nn.IrrepsArray) -> TensorProductFn:
+    def _tensor_product(x: e3nn.IrrepsArray, y: Optional[e3nn.IrrepsArray] = None) -> TensorProductFn:
         """Applies an O(3) equivariant linear parametrized tensor product layer.
 
         Args:
@@ -210,7 +210,7 @@ def O3TensorProductLegacy(
             The output to the weighted tensor product (IrrepsArray).
         """
 
-        if not y:
+        if y is None:
             y = e3nn.IrrepsArray("1x0e", jnp.ones((1, 1)))
 
         if x.irreps.lmax == 0 and y.irreps.lmax == 0 and output_irreps.lmax > 0:

--- a/segnn_jax/blocks.py
+++ b/segnn_jax/blocks.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Callable, Optional, Tuple, Union, Any
+from typing import Any, Callable, Optional, Tuple, Union
 
 import e3nn_jax as e3nn
 import haiku as hk
@@ -8,7 +8,6 @@ import jax.numpy as jnp
 from e3nn_jax._src.tensor_products import naive_broadcast_decorator
 
 from .graph_utils import SteerableGraphsTuple
-
 
 InitFn = Callable[[str, Tuple[int, ...], float, Any], jnp.ndarray]
 
@@ -22,7 +21,7 @@ class O3TensorProduct(hk.Module):
         name: Name of the linear layer params
         init_fn: Weight initialization function
         gradient_normalization: Gradient normalization method. Default is "path"
-            NOTE: gradient_normalization="element" for 1/sqrt(fanin) initialization. 
+            NOTE: gradient_normalization="element" for 1/sqrt(fanin) initialization.
             This is the default in torch and is similar to what is used in the original
             code (tp_rescale).
         path_normalization: Path normalization method. Default is "element"
@@ -49,6 +48,7 @@ class O3TensorProduct(hk.Module):
         self._biases = biases
 
         if not init_fn:
+
             def init_fn(
                 name: str,
                 path_shape: Tuple[int, ...],
@@ -138,15 +138,19 @@ class O3TensorProduct(hk.Module):
             b = [
                 self._init_fn(
                     f"b[{i_out}] {tp.irreps_out[i_out]}",
-                    (mul_ir.dim, ),
+                    (mul_ir.dim,),
                     0.0,
                     x.dtype,
                 )
                 for i_out, mul_ir in enumerate(self.output_irreps)
                 if mul_ir.ir.is_scalar()
             ]
-            b = e3nn.IrrepsArray(f"{self.output_irreps.count('0e')}x0e", jnp.concatenate(b))    
-            output = e3nn.concatenate([output.filter("0e") + b, output.filter(drop="0e")], axis=1)
+            b = e3nn.IrrepsArray(
+                f"{self.output_irreps.count('0e')}x0e", jnp.concatenate(b)
+            )
+            output = e3nn.concatenate(
+                [output.filter("0e") + b, output.filter(drop="0e")], axis=1
+            )
 
         return output
 

--- a/segnn_jax/blocks.py
+++ b/segnn_jax/blocks.py
@@ -11,7 +11,9 @@ from .config import config
 from .graph_utils import SteerableGraphsTuple
 
 InitFn = Callable[[str, Tuple[int, ...], float, Any], jnp.ndarray]
-TensorProductFn = Callable[[e3nn.IrrepsArray, Optional[e3nn.IrrepsArray]], e3nn.IrrepsArray]
+TensorProductFn = Callable[
+    [e3nn.IrrepsArray, Optional[e3nn.IrrepsArray]], e3nn.IrrepsArray
+]
 
 
 def uniform_init(
@@ -199,7 +201,9 @@ def O3TensorProductLegacy(
         path_normalization=path_normalization,
     )
 
-    def _tensor_product(x: e3nn.IrrepsArray, y: Optional[e3nn.IrrepsArray] = None) -> TensorProductFn:
+    def _tensor_product(
+        x: e3nn.IrrepsArray, y: Optional[e3nn.IrrepsArray] = None
+    ) -> TensorProductFn:
         """Applies an O(3) equivariant linear parametrized tensor product layer.
 
         Args:

--- a/segnn_jax/blocks.py
+++ b/segnn_jax/blocks.py
@@ -362,3 +362,15 @@ def O3Embedding(embed_irreps: e3nn.Irreps, embed_edges: bool = True) -> Callable
         return st_graph
 
     return _embedding
+
+
+class BatchNormWrapper(hk.Module):
+    """Named wrapper for e3nn.haiku.BatchNorm."""
+
+    def __init__(self, name: str = None, **kwargs):
+        # TODO only to name norms. Remove when e3nn.haiku.BatchNorm supports naming
+        super().__init__(name=name)
+        self._norm = e3nn.haiku.BatchNorm(**kwargs)
+
+    def __call__(self, x: e3nn.IrrepsArray) -> e3nn.IrrepsArray:
+        return self._norm(x)

--- a/segnn_jax/blocks.py
+++ b/segnn_jax/blocks.py
@@ -7,9 +7,25 @@ import jax
 import jax.numpy as jnp
 from e3nn_jax._src.tensor_products import naive_broadcast_decorator
 
+from .config import config
 from .graph_utils import SteerableGraphsTuple
 
 InitFn = Callable[[str, Tuple[int, ...], float, Any], jnp.ndarray]
+TensorProductFn = Callable[[e3nn.IrrepsArray, e3nn.IrrepsArray], e3nn.IrrepsArray]
+
+
+def uniform_init(
+    name: str,
+    path_shape: Tuple[int, ...],
+    weight_std: float,
+    dtype: jnp.dtype = config("default_dtype"),
+):
+    return hk.get_parameter(
+        name,
+        shape=path_shape,
+        dtype=dtype,
+        init=hk.initializers.RandomUniform(minval=-weight_std, maxval=weight_std),
+    )
 
 
 class O3TensorProduct(hk.Module):
@@ -19,11 +35,9 @@ class O3TensorProduct(hk.Module):
         output_irreps: Output representation
         biases: If set ot true will add biases
         name: Name of the linear layer params
-        init_fn: Weight initialization function
+        init_fn: Weight initialization function. Default is uniform.
         gradient_normalization: Gradient normalization method. Default is "path"
-            NOTE: gradient_normalization="element" for 1/sqrt(fanin) initialization.
-            This is the default in torch and is similar to what is used in the original
-            code (tp_rescale).
+            NOTE: gradient_normalization="element" is the default in torch and haiku.
         path_normalization: Path normalization method. Default is "element"
     """
 
@@ -36,41 +50,75 @@ class O3TensorProduct(hk.Module):
         biases: bool = True,
         name: Optional[str] = None,
         init_fn: Optional[InitFn] = None,
-        gradient_normalization: Optional[Union[str, float]] = "element",
+        gradient_normalization: Optional[Union[str, float]] = None,
         path_normalization: Optional[Union[str, float]] = None,
     ):
         super().__init__(name)
 
-        self.output_irreps = output_irreps.regroup()
+        self.output_irreps = output_irreps
         if not right_irreps:
             right_irreps = e3nn.Irreps("1x0e")
-        self.right_irreps = right_irreps.regroup()
-        self.left_irreps = left_irreps.regroup()
-
-        self._biases = biases
+        self.right_irreps = right_irreps
+        self.left_irreps = left_irreps
 
         if not init_fn:
+            init_fn = uniform_init
 
-            def init_fn(
-                name: str,
-                path_shape: Tuple[int, ...],
-                weight_std: float,
-                dtype: jnp.dtype = jnp.float32,
-            ):
-                return hk.get_parameter(
-                    name,
-                    shape=path_shape,
-                    dtype=dtype,
-                    init=hk.initializers.RandomNormal(stddev=weight_std),
+        self._get_parameter = init_fn
+
+        if not gradient_normalization:
+            gradient_normalization = config("gradient_normalization")
+        if not path_normalization:
+            path_normalization = config("path_normalization")
+
+        # NOTE FunctionalFullyConnectedTensorProduct appears to be faster than combining
+        #  tensor_product+linear: https://github.com/e3nn/e3nn-jax/releases/tag/0.14.0
+        #  Implementation adapted from e3nn.haiku.FullyConnectedTensorProduct
+        tp = e3nn.FunctionalFullyConnectedTensorProduct(
+            left_irreps,
+            right_irreps,
+            output_irreps,
+            gradient_normalization=gradient_normalization,
+            path_normalization=path_normalization,
+        )
+        ws = [
+            self._get_parameter(
+                name=(
+                    f"w[{ins.i_in1},{ins.i_in2},{ins.i_out}] "
+                    f"{tp.irreps_in1[ins.i_in1]},"
+                    f"{tp.irreps_in2[ins.i_in2]},"
+                    f"{tp.irreps_out[ins.i_out]}"
+                ),
+                path_shape=ins.path_shape,
+                weight_std=ins.weight_std,
+            )
+            for ins in tp.instructions
+        ]
+
+        def tensor_product(x, y, **kwargs):
+            return tp.left_right(ws, x, y, **kwargs)._convert(output_irreps)
+
+        self.tensor_product = naive_broadcast_decorator(tensor_product)
+        self.biases = None
+
+        if biases and "0e" in self.output_irreps:
+            # add biases
+            b = [
+                self._get_parameter(
+                    f"b[{i_out}] {tp.irreps_out[i_out]}",
+                    path_shape=(mul_ir.dim,),
+                    weight_std=1 / jnp.sqrt(mul_ir.dim),
                 )
+                for i_out, mul_ir in enumerate(output_irreps)
+                if mul_ir.ir.is_scalar()
+            ]
+            b = e3nn.IrrepsArray(
+                f"{self.output_irreps.count('0e')}x0e", jnp.concatenate(b)
+            )
 
-        self._init_fn = init_fn
-
-        # NOTE gradient_normalization="element" for 1/sqrt(fanin) initialization
-        #  this is the default in torch and is similar to what is used in the
-        # original code (tp_rescale). On deeper networks could also init with uniform.
-        self._gradient_normalization = gradient_normalization
-        self._path_normalization = path_normalization
+            self.biases = lambda x: e3nn.concatenate(
+                [x.filter("0e") + b, x.filter(drop="0e")], axis=1
+            )
 
     def __call__(
         self, x: e3nn.IrrepsArray, y: Optional[e3nn.IrrepsArray] = None, **kwargs
@@ -88,15 +136,12 @@ class O3TensorProduct(hk.Module):
         if not y:
             y = e3nn.IrrepsArray("1x0e", jnp.ones((1, 1)))
 
-        if x.irreps.lmax == 0 and y.irreps.lmax == 0 and self._output_irreps.lmax > 0:
+        if x.irreps.lmax == 0 and y.irreps.lmax == 0 and self.output_irreps.lmax > 0:
             warnings.warn(
                 f"The specified output irreps ({self.output_irreps}) are not scalars but both "
                 "operands are. This can have undesired behaviour such as null output Try "
                 "redistributing them into scalars or chose higher orders for the operands."
             )
-
-        x = x.remove_nones().regroup()
-        y = y.remove_nones().regroup()
 
         assert (
             x.irreps == self.left_irreps
@@ -105,119 +150,152 @@ class O3TensorProduct(hk.Module):
             y.irreps == self.right_irreps
         ), f"Right irreps do not match. Got {y.irreps}, expected {self.right_irreps}"
 
-        # NOTE FunctionalFullyConnectedTensorProduct appears to be faster than combining
-        #  tensor_product+linear: https://github.com/e3nn/e3nn-jax/releases/tag/0.14.0
-        #  Implementation adapted from e3nn.haiku.FullyConnectedTensorProduct
+        output = self.tensor_product(x, y, **kwargs)
 
-        tp = e3nn.FunctionalFullyConnectedTensorProduct(
-            x.irreps,
-            y.irreps,
-            self.output_irreps.simplify(),
-            irrep_normalization="component",
-            gradient_normalization=self._gradient_normalization,
-            path_normalization=self._path_normalization,
-        )
-
-        ws = [
-            self._init_fn(
-                name=(
-                    f"w[{ins.i_in1},{ins.i_in2},{ins.i_out}] "
-                    f"{tp.irreps_in2[ins.i_in2]},{tp.irreps_out[ins.i_out]}"
-                ),
-                path_shape=ins.path_shape,
-                weight_std=ins.weight_std,
-                dtype=x.dtype,
-            )
-            for ins in tp.instructions
-        ]
-
-        f = naive_broadcast_decorator(
-            lambda x1, y1: tp.left_right(ws, x1, y1, **kwargs)
-        )
-        output = f(x, y)._convert(self.output_irreps)
-
-        if self._biases and "0e" in self.output_irreps:
+        if self.biases:
             # add biases
-            b = [
-                self._init_fn(
-                    f"b[{i_out}] {tp.irreps_out[i_out]}",
-                    (mul_ir.dim,),
-                    0.0,
-                    x.dtype,
-                )
-                for i_out, mul_ir in enumerate(self.output_irreps)
-                if mul_ir.ir.is_scalar()
-            ]
-            b = e3nn.IrrepsArray(
-                f"{self.output_irreps.count('0e')}x0e", jnp.concatenate(b)
-            )
-            output = e3nn.concatenate(
-                [output.filter("0e") + b, output.filter(drop="0e")], axis=1
-            )
+            return self.biases(output)
 
         return output
 
 
-class O3TensorProductGate(O3TensorProduct):
+def O3TensorProductLegacy(
+    output_irreps: e3nn.Irreps,
+    *,
+    left_irreps: e3nn.Irreps,
+    right_irreps: Optional[e3nn.Irreps] = None,
+    biases: bool = True,
+    name: Optional[str] = None,
+    init_fn: Optional[InitFn] = None,
+    gradient_normalization: Optional[Union[str, float]] = "element",
+    path_normalization: Optional[Union[str, float]] = None,
+):
+    """O(3) equivariant linear parametrized tensor product layer.
+    Legacy version of O3TensorProduct that uses e3nn.haiku.Linear instead of
+    e3nn.FunctionalFullyConnectedTensorProduct.
+
+    Args:
+        output_irreps: Output representation
+        biases: If set ot true will add biases
+        name: Name of the linear layer params
+        init_fn: Weight initialization function. Default is uniform.
+        gradient_normalization: Gradient normalization method. Default is "path"
+            NOTE: gradient_normalization="element" is the default in torch and haiku.
+        path_normalization: Path normalization method. Default is "element"
+
+    Returns:
+        A function that returns the output to the weighted tensor product.
+    """
+
+    if not init_fn:
+        init_fn = uniform_init
+
+    linear = e3nn.haiku.Linear(
+        output_irreps,
+        get_parameter=init_fn,
+        biases=biases,
+        name=name,
+        gradient_normalization=gradient_normalization,
+        path_normalization=path_normalization,
+    )
+
+    def _tensor_product(x: e3nn.IrrepsArray, y: e3nn.IrrepsArray) -> TensorProductFn:
+        """Applies an O(3) equivariant linear parametrized tensor product layer.
+
+        Args:
+            x (IrrepsArray): Left tensor
+            y (IrrepsArray): Right tensor. If None it defaults to np.ones.
+
+        Returns:
+            The output to the weighted tensor product (IrrepsArray).
+        """
+
+        if not y:
+            y = e3nn.IrrepsArray("1x0e", jnp.ones((1, 1)))
+
+        if x.irreps.lmax == 0 and y.irreps.lmax == 0 and output_irreps.lmax > 0:
+            warnings.warn(
+                f"The specified output irreps ({output_irreps}) are not scalars but both "
+                "operands are. This can have undesired behaviour such as null output Try "
+                "redistributing them into scalars or chose higher orders for the operands."
+            )
+
+        assert (
+            x.irreps == left_irreps
+        ), f"Left irreps do not match. Got {x.irreps}, expected {left_irreps}"
+        assert (
+            y.irreps == right_irreps
+        ), f"Right irreps do not match. Got {y.irreps}, expected {right_irreps}"
+
+        tp = e3nn.tensor_product(x, y)
+
+        return linear(tp)
+
+    return _tensor_product
+
+
+O3Layer = O3TensorProduct if config("o3_layer") == "new" else O3TensorProductLegacy
+
+
+def O3TensorProductGate(
+    output_irreps: e3nn.Irreps,
+    *,
+    left_irreps: e3nn.Irreps,
+    right_irreps: Optional[e3nn.Irreps] = None,
+    biases: bool = True,
+    scalar_activation: Optional[Callable] = None,
+    gate_activation: Optional[Callable] = None,
+    name: Optional[str] = None,
+    init_fn: Optional[InitFn] = None,
+) -> TensorProductFn:
     """Non-linear (gated) O(3) equivariant linear tensor product layer.
 
     The tensor product lifts the input representation to have gating scalars.
 
-    Attributes:
+    Args:
         output_irreps: Output representation
         biases: Add biases
         scalar_activation: Activation function for scalars
         gate_activation: Activation function for higher order
         name: Name of the linear layer params
+
+    Returns:
+        Function that applies the gated tensor product layer.
     """
+    # lift output with gating scalars
+    gate_irreps = e3nn.Irreps(
+        f"{output_irreps.num_irreps - output_irreps.count('0e')}x0e"
+    )
+    tensor_product = O3Layer(
+        (gate_irreps + output_irreps).regroup(),
+        left_irreps=left_irreps,
+        right_irreps=right_irreps,
+        biases=biases,
+        name=name,
+        init_fn=init_fn,
+    )
+    if scalar_activation is None:
+        scalar_activation = jax.nn.silu
+    if gate_activation is None:
+        gate_activation = jax.nn.sigmoid
 
-    def __init__(
-        self,
-        output_irreps: e3nn.Irreps,
-        *,
-        left_irreps: e3nn.Irreps,
-        right_irreps: Optional[e3nn.Irreps] = None,
-        biases: bool = True,
-        scalar_activation: Optional[Callable] = None,
-        gate_activation: Optional[Callable] = None,
-        name: Optional[str] = None,
-        init_fn: Optional[InitFn] = None,
-    ):
-        super().__init__(
-            output_irreps,
-            left_irreps=left_irreps,
-            right_irreps=right_irreps,
-            biases=biases,
-            name=name,
-            init_fn=init_fn,
-        )
-        if scalar_activation is None:
-            self.scalar_activation = jax.nn.silu
-        if gate_activation is None:
-            self.gate_activation = jax.nn.sigmoid
-
-        # lift input with gating scalars
-        self.gate_irreps = e3nn.Irreps(
-            f"{output_irreps.num_irreps - output_irreps.count('0e')}x0e"
-        )
-
-    def __call__(
-        self, x: e3nn.IrrepsArray, y: Optional[e3nn.IrrepsArray] = None, **kwargs
+    def _gated_tensor_product(
+        x: e3nn.IrrepsArray, y: Optional[e3nn.IrrepsArray] = None, **kwargs
     ) -> e3nn.IrrepsArray:
-        tp = super().__call__(x, y, **kwargs)
-        return e3nn.gate(
-            tp, even_act=self.scalar_activation, odd_gate_act=self.gate_activation
-        )
+        tp = tensor_product(x, y, **kwargs)
+        return e3nn.gate(tp, even_act=scalar_activation, odd_gate_act=gate_activation)
+
+    return _gated_tensor_product
 
 
-def O3Embedding(embed_irreps: e3nn.Irreps, embed_msg_features: bool = True) -> Callable:
+def O3Embedding(embed_irreps: e3nn.Irreps, embed_edges: bool = True) -> Callable:
     """Linear steerable embedding.
 
     Embeds the graph nodes in the representation space :param embed_irreps:.
 
     Args:
         embed_irreps: Output representation
-        embed_msg_features: If true also embed edges/message passing features
+        embed_edges: If true also embed edges/message passing features
 
     Returns:
         Function to embed graph nodes (and optionally edges)
@@ -228,20 +306,20 @@ def O3Embedding(embed_irreps: e3nn.Irreps, embed_msg_features: bool = True) -> C
     ) -> SteerableGraphsTuple:
         # TODO update
         graph = st_graph.graph
-        nodes = O3TensorProduct(
+        nodes = O3Layer(
             embed_irreps,
             left_irreps=graph.nodes.irreps,
             right_irreps=st_graph.node_attributes.irreps,
-            name="o3_embedding_nodes",
+            name="embedding_nodes",
         )(graph.nodes, st_graph.node_attributes)
         st_graph = st_graph._replace(graph=graph._replace(nodes=nodes))
 
-        if embed_msg_features:
-            additional_message_features = O3TensorProduct(
+        if embed_edges:
+            additional_message_features = O3Layer(
                 embed_irreps,
                 left_irreps=graph.nodes.irreps,
                 right_irreps=st_graph.node_attributes.irreps,
-                name="o3_embedding_msg_features",
+                name="embedding_msg_features",
             )(
                 st_graph.additional_message_features,
                 st_graph.edge_attributes,

--- a/segnn_jax/blocks.py
+++ b/segnn_jax/blocks.py
@@ -1,142 +1,259 @@
 import warnings
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, Union, Any
 
 import e3nn_jax as e3nn
 import haiku as hk
 import jax
 import jax.numpy as jnp
+from e3nn_jax._src.tensor_products import naive_broadcast_decorator
 
 from .graph_utils import SteerableGraphsTuple
 
 
-def _uniform_initialization(name: str, path_shape: Tuple[int, ...], weight_std: float):
-    # initialize all params with uniform (also biases)
-    return hk.get_parameter(
-        name,
-        shape=path_shape,
-        init=hk.initializers.RandomUniform(-weight_std, weight_std),
-    )
+InitFn = Callable[[str, Tuple[int, ...], float, Any], jnp.ndarray]
 
 
-def O3TensorProduct(
-    x: e3nn.IrrepsArray,
-    y: Optional[e3nn.IrrepsArray],
-    output_irreps: e3nn.Irreps,
-    biases: bool = True,
-    name: Optional[str] = None,
-    uniform_initialization: bool = False,
-) -> e3nn.IrrepsArray:
-    """Applies a linear parametrized tensor product layer.
+class O3TensorProduct(hk.Module):
+    """O(3) equivariant linear parametrized tensor product layer.
 
-    Args:
-        x (IrrepsArray): Left tensor
-        y (IrrepsArray): Right tensor. If None it defaults to np.ones.
+    Attributes:
         output_irreps: Output representation
         biases: If set ot true will add biases
         name: Name of the linear layer params
-        uniform_initialization: Initialize weights from a uniform distribution
-
-    Returns:
-        The output to the weighted tensor product (IrrepsArray).
+        init_fn: Weight initialization function
+        gradient_normalization: Gradient normalization method. Default is "path"
+            NOTE: gradient_normalization="element" for 1/sqrt(fanin) initialization. 
+            This is the default in torch and is similar to what is used in the original
+            code (tp_rescale).
+        path_normalization: Path normalization method. Default is "element"
     """
 
-    if not y:
-        y = e3nn.IrrepsArray("1x0e", jnp.ones((x.shape[0], 1)))
+    def __init__(
+        self,
+        output_irreps: e3nn.Irreps,
+        *,
+        left_irreps: e3nn.Irreps,
+        right_irreps: Optional[e3nn.Irreps] = None,
+        biases: bool = True,
+        name: Optional[str] = None,
+        init_fn: Optional[InitFn] = None,
+        gradient_normalization: Optional[Union[str, float]] = "element",
+        path_normalization: Optional[Union[str, float]] = None,
+    ):
+        super().__init__(name)
 
-    if x.irreps.lmax == 0 and y.irreps.lmax == 0 and output_irreps.lmax > 0:
-        warnings.warn(
-            f"The specified output irreps ({output_irreps}) are not scalars but both "
-            "operands are. This can have undesired behaviour such as null output Try "
-            "redistributing them into scalars or chose higher orders for the operands."
+        self.output_irreps = output_irreps
+        self.right_irreps = right_irreps
+        self.left_irreps = left_irreps
+
+        self._biases = biases
+
+        if not init_fn:
+            def init_fn(
+                name: str,
+                path_shape: Tuple[int, ...],
+                weight_std: float,
+                dtype: jnp.dtype = jnp.float32,
+            ):
+                return hk.get_parameter(
+                    name,
+                    shape=path_shape,
+                    dtype=dtype,
+                    init=hk.initializers.RandomNormal(stddev=weight_std),
+                )
+
+        self._init_fn = init_fn
+
+        # NOTE gradient_normalization="element" for 1/sqrt(fanin) initialization
+        #  this is the default in torch and is similar to what is used in the
+        # original code (tp_rescale). On deeper networks could also init with uniform.
+        self._gradient_normalization = gradient_normalization
+        self._path_normalization = path_normalization
+
+    def __call__(
+        self, x: e3nn.IrrepsArray, y: Optional[e3nn.IrrepsArray] = None, **kwargs
+    ) -> e3nn.IrrepsArray:
+        """Applies an O(3) equivariant linear parametrized tensor product layer.
+
+        Args:
+            x (IrrepsArray): Left tensor
+            y (IrrepsArray): Right tensor. If None it defaults to np.ones.
+
+        Returns:
+            The output to the weighted tensor product (IrrepsArray).
+        """
+
+        if not y:
+            y = e3nn.IrrepsArray("1x0e", jnp.ones((x.shape[0], 1)))
+
+        if x.irreps.lmax == 0 and y.irreps.lmax == 0 and self._output_irreps.lmax > 0:
+            warnings.warn(
+                f"The specified output irreps ({self.output_irreps}) are not scalars but both "
+                "operands are. This can have undesired behaviour such as null output Try "
+                "redistributing them into scalars or chose higher orders for the operands."
+            )
+
+        # NOTE FunctionalFullyConnectedTensorProduct appears to be faster than combining
+        #  tensor_product+linear: https://github.com/e3nn/e3nn-jax/releases/tag/0.14.0
+        #  Implementation adapted from e3nn.haiku.FullyConnectedTensorProduct
+
+        if self.left_irreps is not None:
+            x = x._convert(self.left_irreps)
+        if self.right_irreps is not None:
+            y = y._convert(self.right_irreps)
+
+        x = x.remove_nones().simplify()
+        y = y.remove_nones().simplify()
+
+        tp = e3nn.FunctionalFullyConnectedTensorProduct(
+            x.irreps,
+            y.irreps,
+            self.output_irreps.simplify(),
+            irrep_normalization="component",
+            gradient_normalization=self._gradient_normalization,
+            path_normalization=self._path_normalization,
         )
 
-    tp = e3nn.tensor_product(x, y, irrep_normalization="component")
-    # NOTE gradient_normalization="element" for 1/sqrt(fanin) initialization
-    #  this is the default in torch and is similar to what is used in the
-    #  original code (tp_rescale). On deeper networks could also init with uniform.
-    return e3nn.Linear(
-        output_irreps,
-        biases=biases,
-        gradient_normalization="element",
-        name=name,
-        get_parameter=(_uniform_initialization if uniform_initialization else None),
-    )(tp)
+        ws = [
+            self._init_fn(
+                name=(
+                    f"w[{ins.i_in1},{ins.i_in2},{ins.i_out}] "
+                    f"{tp.irreps_in2[ins.i_in2]},{tp.irreps_out[ins.i_out]}"
+                    # f"{tp.irreps_in1[ins.i_in1]},{tp.irreps_in2[ins.i_in2]},{tp.irreps_out[ins.i_out]}"
+                ),
+                path_shape=ins.path_shape,
+                weight_std=ins.weight_std,
+                dtype=x.dtype,
+            )
+            for ins in tp.instructions
+        ]
+
+        f = naive_broadcast_decorator(
+            lambda x1, y1: tp.left_right(ws, x1, y1, **kwargs)
+        )
+        output = f(x, y)._convert(self.output_irreps)
+
+        if self._biases and "0e" in self.output_irreps:
+            # add biases
+            b = [
+                self._init_fn(
+                    f"b[{i_out}] {tp.irreps_out[i_out]}",
+                    (mul_ir.dim, ),
+                    0.0,
+                    x.dtype,
+                )
+                for i_out, mul_ir in enumerate(self.output_irreps)
+                if mul_ir.ir.is_scalar()
+            ]
+            b = e3nn.IrrepsArray(f"{self.output_irreps.count('0e')}x0e", jnp.concatenate(b))    
+            output = e3nn.concatenate([output.filter("0e") + b, output.filter(drop="0e")], axis=1)
+
+        return output
 
 
-def O3TensorProductGate(
-    x: e3nn.IrrepsArray,
-    y: e3nn.IrrepsArray,
-    output_irreps: e3nn.Irreps,
-    biases: bool = True,
-    scalar_activation: Optional[Callable] = None,
-    gate_activation: Optional[Callable] = None,
-    name: Optional[str] = None,
-) -> e3nn.IrrepsArray:
-    """Applies a non-linear (gate) parametrized tensor product layer.
+class O3TensorProductGate(O3TensorProduct):
+    """Non-linear (gated) O(3) equivariant linear tensor product layer.
 
     The tensor product lifts the input representation to have gating scalars.
 
-    Args:
-        x (IrrepsArray): Left tensor
-        y (IrrepsArray): Right tensor
+    Attributes:
         output_irreps: Output representation
         biases: Add biases
         scalar_activation: Activation function for scalars
         gate_activation: Activation function for higher order
         name: Name of the linear layer params
-
-    Returns:
-        The output to the weighted tensor product (IrrepsArray).
     """
 
-    if scalar_activation is None:
-        scalar_activation = jax.nn.silu
-    if gate_activation is None:
-        gate_activation = jax.nn.sigmoid
+    def __init__(
+        self,
+        output_irreps: e3nn.Irreps,
+        *,
+        left_irreps: e3nn.Irreps,
+        right_irreps: Optional[e3nn.Irreps] = None,
+        biases: bool = True,
+        scalar_activation: Optional[Callable] = None,
+        gate_activation: Optional[Callable] = None,
+        name: Optional[str] = None,
+        init_fn: Optional[InitFn] = None,
+    ):
+        super().__init__(
+            output_irreps,
+            left_irreps=left_irreps,
+            right_irreps=right_irreps,
+            biases=biases,
+            name=name,
+            init_fn=init_fn,
+        )
+        if scalar_activation is None:
+            self.scalar_activation = jax.nn.silu
+        if gate_activation is None:
+            self.gate_activation = jax.nn.sigmoid
 
-    # lift input with gating scalars
-    gate_irreps = e3nn.Irreps(
-        f"{output_irreps.num_irreps - output_irreps.count('0e')}x0e"
-    )
+        # lift input with gating scalars
+        self.gate_irreps = e3nn.Irreps(
+            f"{output_irreps.num_irreps - output_irreps.count('0e')}x0e"
+        )
 
-    tp = O3TensorProduct(
-        x, y, (gate_irreps + output_irreps).regroup(), biases, name=name
-    )
-    return e3nn.gate(tp, even_act=scalar_activation, odd_gate_act=gate_activation)
+    def __call__(
+        self, x: e3nn.IrrepsArray, y: Optional[e3nn.IrrepsArray] = None, **kwargs
+    ) -> e3nn.IrrepsArray:
+        tp = super().__call__(x, y, **kwargs)
+        return e3nn.gate(
+            tp, even_act=self.scalar_activation, odd_gate_act=self.gate_activation
+        )
 
 
-def O3Embedding(
-    st_graph: SteerableGraphsTuple,
-    embed_irreps: e3nn.Irreps,
-    embed_msg_features: bool = True,
-) -> SteerableGraphsTuple:
-    """Linear steerable embedding for the graph nodes.
+class O3Embedding(hk.Module):
+    """Linear steerable embedding.
 
     Embeds the graph nodes in the representation space :param embed_irreps:.
 
-    Args:
-        st_graph (SteerableGraphsTuple): Input graph
+    Attributes:
         embed_irreps: Output representation
         embed_msg_features: If true also embed edges/message passing features
-
-    Returns:
-        The graph with replaced node embedding.
     """
-    graph = st_graph.graph
-    nodes = O3TensorProduct(
-        graph.nodes, st_graph.node_attributes, embed_irreps, name="o3_embedding_nodes"
-    )
-    st_graph = st_graph._replace(graph=graph._replace(nodes=nodes))
 
-    if embed_msg_features:
-        additional_message_features = O3TensorProduct(
-            st_graph.additional_message_features,
-            st_graph.edge_attributes,
-            embed_irreps,
-            name="o3_embedding_msg_features",
-        )
-        st_graph = st_graph._replace(
-            additional_message_features=additional_message_features
-        )
+    def __init__(self, embed_irreps: e3nn.Irreps, embed_msg_features: bool = True):
+        super().__init__()
+        self.embed_irreps = embed_irreps
+        self.embed_msg_features = embed_msg_features
 
-    return st_graph
+    def __call__(
+        self,
+        st_graph: SteerableGraphsTuple,
+    ) -> SteerableGraphsTuple:
+        """Apply linear steerable embedding.
+
+        Embeds the graph nodes in the representation space :param embed_irreps:.
+
+        Args:
+            st_graph (SteerableGraphsTuple): Input graph
+
+        Returns:
+            The graph with replaced node embedding.
+        """
+        # TODO update
+        graph = st_graph.graph
+        nodes = O3TensorProduct(
+            self.embed_irreps,
+            left_irreps=graph.nodes.irreps,
+            right_irreps=st_graph.node_attributes.irreps,
+            name="o3_embedding_nodes",
+        )(graph.nodes, st_graph.node_attributes)
+        st_graph = st_graph._replace(graph=graph._replace(nodes=nodes))
+
+        if self.embed_msg_features:
+            additional_message_features = O3TensorProduct(
+                self.embed_irreps,
+                left_irreps=graph.nodes.irreps,
+                right_irreps=st_graph.node_attributes.irreps,
+                name="o3_embedding_msg_features",
+            )(
+                st_graph.additional_message_features,
+                st_graph.edge_attributes,
+            )
+            st_graph = st_graph._replace(
+                additional_message_features=additional_message_features
+            )
+
+        return st_graph

--- a/segnn_jax/blocks.py
+++ b/segnn_jax/blocks.py
@@ -242,9 +242,9 @@ def O3TensorProductLegacy(
 
         if x.irreps.lmax == 0 and y.irreps.lmax == 0 and output_irreps.lmax > 0:
             warnings.warn(
-                f"The specified output irreps ({output_irreps}) are not scalars but both "
-                "operands are. This can have undesired behaviour such as null output Try "
-                "redistributing them into scalars or chose higher orders for the operands."
+                f"The specified output irreps ({output_irreps}) are not scalars "
+                "but both operands are. This can have undesired behaviour (NaN). Try "
+                "redistributing them into scalars or choose higher orders."
             )
 
         assert (
@@ -345,6 +345,7 @@ def O3Embedding(embed_irreps: e3nn.Irreps, embed_edges: bool = True) -> Callable
         )(graph.nodes, st_graph.node_attributes)
         st_graph = st_graph._replace(graph=graph._replace(nodes=nodes))
 
+        # NOTE edge embedding is not in the original paper but can get good results
         if embed_edges:
             additional_message_features = O3Layer(
                 embed_irreps,
@@ -362,15 +363,3 @@ def O3Embedding(embed_irreps: e3nn.Irreps, embed_edges: bool = True) -> Callable
         return st_graph
 
     return _embedding
-
-
-class BatchNormWrapper(hk.Module):
-    """Named wrapper for e3nn.haiku.BatchNorm."""
-
-    def __init__(self, name: str = None, **kwargs):
-        # TODO only to name norms. Remove when e3nn.haiku.BatchNorm supports naming
-        super().__init__(name=name)
-        self._norm = e3nn.haiku.BatchNorm(**kwargs)
-
-    def __call__(self, x: e3nn.IrrepsArray) -> e3nn.IrrepsArray:
-        return self._norm(x)

--- a/segnn_jax/config.py
+++ b/segnn_jax/config.py
@@ -10,3 +10,7 @@ __conf = {
 
 def config(key):
     return __conf[key]
+
+
+def set_config(key, val):
+    __conf[key] = val

--- a/segnn_jax/config.py
+++ b/segnn_jax/config.py
@@ -1,0 +1,12 @@
+import jax.numpy as jnp
+
+__conf = {
+    "gradient_normalization": "element",  # "element" or "path"
+    "path_normalization": "element",  # "element" or "path"
+    "default_dtype": jnp.float32,
+    "o3_layer": "legacy",  # "new" or "legacy"
+}
+
+
+def config(key):
+    return __conf[key]

--- a/segnn_jax/config.py
+++ b/segnn_jax/config.py
@@ -10,7 +10,3 @@ __conf = {
 
 def config(key):
     return __conf[key]
-
-
-def set_config(key, val):
-    __conf[key] = val

--- a/segnn_jax/config.py
+++ b/segnn_jax/config.py
@@ -4,7 +4,7 @@ __conf = {
     "gradient_normalization": "element",  # "element" or "path"
     "path_normalization": "element",  # "element" or "path"
     "default_dtype": jnp.float32,
-    "o3_layer": "legacy",  # "new" or "legacy"
+    "o3_layer": "new",  # "new" or "legacy"
 }
 
 

--- a/segnn_jax/graph_utils.py
+++ b/segnn_jax/graph_utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, NamedTuple, Optional, Tuple
+from typing import Callable, NamedTuple, Optional
 
 import e3nn_jax as e3nn
 import jax.numpy as jnp

--- a/segnn_jax/graph_utils.py
+++ b/segnn_jax/graph_utils.py
@@ -12,9 +12,8 @@ class SteerableGraphsTuple(NamedTuple):
     graph: jraph.GraphsTuple
     node_attributes: Optional[e3nn.IrrepsArray] = None
     edge_attributes: Optional[e3nn.IrrepsArray] = None
-    # NOTE must put additional_message_features in a separate field otherwise
-    #  it would get updated by jraph.GraphNetwork (which goes against one of
-    #  the core ideas of the paper).
+    # NOTE: additional_message_features is in a separate field otherwise it would get
+    #  updated by jraph.GraphNetwork. Actual graph edges are used only for the messages.
     additional_message_features: Optional[e3nn.IrrepsArray] = None
 
 

--- a/segnn_jax/segnn.py
+++ b/segnn_jax/segnn.py
@@ -208,6 +208,11 @@ class SEGNN(hk.Module):
         self._norm = norm
         self._blocks_per_layer = blocks_per_layer
 
+        self._embedding = O3Embedding(
+            self._hidden_irreps_units[0],
+            embed_msg_features=self._embed_msg_features,
+        )
+
         self._decoder = SEDecoder(
             latent_irreps=self._hidden_irreps_units[-1],
             output_irreps=output_irreps,
@@ -251,12 +256,7 @@ class SEGNN(hk.Module):
     def __call__(self, st_graph: SteerableGraphsTuple) -> jnp.array:
         # embedding
         # NOTE edge embedding is not in the original paper but can get good results
-        st_graph = O3Embedding(
-            self._hidden_irreps_units[0],
-            embed_msg_features=self._embed_msg_features,
-        )(
-            st_graph,
-        )
+        st_graph = self._embedding(st_graph)
 
         # message passing layers
         for n, hrp in enumerate(self._hidden_irreps_units):

--- a/segnn_jax/segnn.py
+++ b/segnn_jax/segnn.py
@@ -59,7 +59,7 @@ def SEDecoder(
                 left_irreps=nodes.irreps,
                 right_irreps=st_graph.node_attributes.irreps,
                 name=f"prepool_{blocks}",
-            )
+            )(nodes, st_graph.node_attributes)
 
             # pooling layer
             if pool == "avg":
@@ -73,10 +73,10 @@ def SEDecoder(
             for i in range(blocks):
                 nodes = O3TensorProductGate(
                     pooled_irreps, left_irreps=nodes.irreps, name=f"postpool_{i}"
-                )(nodes, None)
-            nodes = O3Layer(output_irreps, left_irreps=nodes.irreps, name="output")(
-                nodes, None
-            )
+                )(nodes)
+            nodes = O3Layer(
+                output_irreps, left_irreps=nodes.irreps, name="output"
+            )(nodes)
 
         return nodes
 
@@ -154,10 +154,7 @@ def SEGNNLayer(
             left_irreps=x.irreps,
             right_irreps=node_attribute.irreps,
             name=f"update_{blocks - 1}_{layer_num}",
-        )(
-            x,
-            node_attribute,
-        )
+        )(x, node_attribute)
         # residual connection
         nodes += update
         # message norm

--- a/segnn_jax/segnn.py
+++ b/segnn_jax/segnn.py
@@ -146,7 +146,7 @@ class SEGNNLayer(hk.Module):
         blocks: int = 2,
         norm: Optional[str] = None,
     ):
-        super().__init__(name=f"layer_{layer_num}")
+        super().__init__(f"layer_{layer_num}")
         assert norm in ["batch", "instance", "none", None], f"Unknown norm '{norm}'"
         self._output_irreps = output_irreps
         self._blocks = blocks
@@ -251,7 +251,7 @@ class SEGNN(hk.Module):
         hidden_irreps: Feature representation in the hidden layers
         output_irreps: Output representation.
         num_layers: Number of message passing layers
-        norm: Normalization type. Either be None, 'instance' or 'batch'
+        norm: Normalization type. Either None, 'instance' or 'batch'
         pool: Pooling mode (only for graph-wise tasks)
         task: Specifies where the output is located. Either 'graph' or 'node'
         blocks_per_layer: Number of tensor product blocks in each message passing

--- a/segnn_jax/segnn.py
+++ b/segnn_jax/segnn.py
@@ -122,7 +122,7 @@ def SEGNNLayer(
             msg = O3TensorProductGate(
                 output_irreps,
                 left_irreps=msg.irreps,
-                right_irreps=edge_attribute.irreps,
+                right_irreps=getattr(edge_attribute, "irreps", None),
                 name=f"message_{i}_{layer_num}",
             )(msg, edge_attribute)
         # NOTE: original implementation only applied batch norm to messages
@@ -145,14 +145,14 @@ def SEGNNLayer(
             x = O3TensorProductGate(
                 output_irreps,
                 left_irreps=x.irreps,
-                right_irreps=node_attribute.irreps,
+                right_irreps=getattr(node_attribute, "irreps", None),
                 name=f"update_{i}_{layer_num}",
             )(x, node_attribute)
         # last update layer without activation
         update = O3Layer(
             output_irreps,
             left_irreps=x.irreps,
-            right_irreps=node_attribute.irreps,
+            right_irreps=getattr(node_attribute, "irreps", None),
             name=f"update_{blocks - 1}_{layer_num}",
         )(x, node_attribute)
         # residual connection

--- a/segnn_jax/segnn.py
+++ b/segnn_jax/segnn.py
@@ -201,7 +201,7 @@ class SEGNNLayer(hk.Module):
         """Steerable equivariant update function."""
         _ = senders
         _ = globals_
-        x = e3nn.concatenate((nodes, msg), axis=-1)
+        x = e3nn.concatenate([nodes, msg], axis=-1)
         # update mlp (phi_f in the paper) steered by node attributeibutes
         for i in range(self._blocks - 1):
             x = O3TensorProductGate(

--- a/segnn_jax/segnn.py
+++ b/segnn_jax/segnn.py
@@ -142,9 +142,12 @@ def SEGNNLayer(
         x = e3nn.concatenate((nodes, msg), axis=-1)
         # update mlp (phi_f in the paper) steered by node attributeibutes
         for i in range(blocks - 1):
-            x = O3TensorProductGate(output_irreps, left_irreps=x.irreps, right_irreps=node_attribute.irreps, name=f"update_{i}_{layer_num}")(
-                x, node_attribute
-            )
+            x = O3TensorProductGate(
+                output_irreps,
+                left_irreps=x.irreps,
+                right_irreps=node_attribute.irreps,
+                name=f"update_{i}_{layer_num}",
+            )(x, node_attribute)
         # last update layer without activation
         update = O3TensorProduct(
             output_irreps,

--- a/segnn_jax/segnn.py
+++ b/segnn_jax/segnn.py
@@ -74,9 +74,9 @@ def SEDecoder(
                 nodes = O3TensorProductGate(
                     pooled_irreps, left_irreps=nodes.irreps, name=f"postpool_{i}"
                 )(nodes)
-            nodes = O3Layer(
-                output_irreps, left_irreps=nodes.irreps, name="output"
-            )(nodes)
+            nodes = O3Layer(output_irreps, left_irreps=nodes.irreps, name="output")(
+                nodes
+            )
 
         return nodes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ packages = segnn_jax
 python_requires = >=3.8
 install_requires =
     dm_haiku==0.0.9
-    e3nn_jax==0.14.0
+    e3nn_jax==0.17.0
     jax==0.4.1
     jaxlib==0.4.1
     jraph==0.0.6.dev0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 
 
 @pytest.fixture
-def rand_graph():
+def dummy_graph():
     def _rand_graph(n_graphs: int = 1):
         return SteerableGraphsTuple(
             graph=jraph.GraphsTuple(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+import os
+
+import e3nn_jax as e3nn
+import jax
+import jax.numpy as jnp
+import jraph
+import pytest
+
+from segnn_jax import SteerableGraphsTuple
+
+os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
+os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+
+
+@pytest.fixture
+def rand_graph():
+    def _rand_graph(n_graphs: int = 1):
+        return SteerableGraphsTuple(
+            graph=jraph.GraphsTuple(
+                nodes=e3nn.IrrepsArray("1x1o", jnp.ones((n_graphs * 5, 3))),
+                edges=None,
+                senders=jnp.zeros((10 * n_graphs,), dtype=jnp.int32),
+                receivers=jnp.zeros((10 * n_graphs,), dtype=jnp.int32),
+                n_node=jnp.array([5] * n_graphs),
+                n_edge=jnp.array([10] * n_graphs),
+                globals=None,
+            ),
+            additional_message_features=None,
+            edge_attributes=None,
+            node_attributes=e3nn.IrrepsArray("1x0e+1x1o", jnp.ones((n_graphs * 5, 4))),
+        )
+
+    return _rand_graph
+
+
+@pytest.fixture
+def key():
+    return jax.random.PRNGKey(0)

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,0 +1,71 @@
+import e3nn_jax as e3nn
+import haiku as hk
+import pytest
+from e3nn_jax.util import assert_equivariant
+
+from segnn_jax import O3TensorProduct, O3TensorProductGate, O3TensorProductLegacy
+
+
+@pytest.mark.parametrize("biases", [False, True])
+def test_linear(key, biases):
+    f = lambda x1, x2: O3TensorProduct(
+        "1x1o", left_irreps="1x1o", right_irreps="1x1o", biases=biases
+    )(x1, x2)
+    f = hk.without_apply_rng(hk.transform(f))
+
+    v = e3nn.normal("1x1o", key, (5,))
+    params = f.init(key, v, v)
+
+    wrapper = lambda x1, x2: f.apply(params, x1, x2)
+
+    assert_equivariant(
+        wrapper,
+        key,
+        args_in=(e3nn.normal("1x1o", key, (5,)), e3nn.normal("1x1o", key, (5,))),
+    )
+
+
+@pytest.mark.parametrize("biases", [False, True])
+def test_gated(key, biases):
+    import segnn_jax.blocks
+
+    segnn_jax.blocks.O3Layer = segnn_jax.blocks.O3TensorProduct
+
+    f = lambda x1, x2: O3TensorProductGate(
+        "1x1o", left_irreps="1x1o", right_irreps="1x1o", biases=biases
+    )(x1, x2)
+    f = hk.without_apply_rng(hk.transform(f))
+
+    v = e3nn.normal("1x1o", key, (5,))
+    params = f.init(key, v, v)
+
+    wrapper = lambda x1, x2: f.apply(params, x1, x2)
+
+    assert_equivariant(
+        wrapper,
+        key,
+        args_in=(e3nn.normal("1x1o", key, (5,)), e3nn.normal("1x1o", key, (5,))),
+    )
+
+
+@pytest.mark.parametrize("biases", [False, True])
+def test_linear_legacy(key, biases):
+    f = lambda x1, x2: O3TensorProductLegacy(
+        "1x1o", left_irreps="1x1o", right_irreps="1x1o", biases=biases
+    )(x1, x2)
+    f = hk.without_apply_rng(hk.transform(f))
+
+    v = e3nn.normal("1x1o", key, (5,))
+    params = f.init(key, v, v)
+
+    wrapper = lambda x1, x2: f.apply(params, x1, x2)
+
+    assert_equivariant(
+        wrapper,
+        key,
+        args_in=(e3nn.normal("1x1o", key, (5,)), e3nn.normal("1x1o", key, (5,))),
+    )
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/test_segnn.py
+++ b/tests/test_segnn.py
@@ -1,0 +1,87 @@
+import e3nn_jax as e3nn
+import haiku as hk
+import jax.numpy as jnp
+import jraph
+import pytest
+from e3nn_jax.util import assert_equivariant
+
+from segnn_jax import SEGNN, SteerableGraphsTuple, weight_balanced_irreps
+
+
+@pytest.fixture
+def rand_graph():
+    def _rand_graph(n_graphs: int = 1):
+        return SteerableGraphsTuple(
+            graph=jraph.GraphsTuple(
+                nodes=e3nn.IrrepsArray("1x1o", jnp.ones((n_graphs * 5, 3))),
+                edges=None,
+                senders=jnp.zeros((10 * n_graphs,), dtype=jnp.int32),
+                receivers=jnp.zeros((10 * n_graphs,), dtype=jnp.int32),
+                n_node=jnp.array([5] * n_graphs),
+                n_edge=jnp.array([10] * n_graphs),
+                globals=None,
+            ),
+            additional_message_features=None,
+            edge_attributes=None,
+            node_attributes=e3nn.IrrepsArray("1x0e+1x1o", jnp.ones((n_graphs * 5, 4))),
+        )
+
+    return _rand_graph
+
+
+@pytest.mark.parametrize("task", ["graph", "node"])
+@pytest.mark.parametrize("norm", ["none", "instance"])
+def test_equivariance(key, rand_graph, norm, task):
+    import segnn_jax.config
+    segnn_jax.config.set_config("o3_layer", "new")
+
+    segnn = lambda x: SEGNN(
+        hidden_irreps=weight_balanced_irreps(8, e3nn.Irreps.spherical_harmonics(1)),
+        output_irreps=e3nn.Irreps("1x1o"),
+        num_layers=1,
+        task=task,
+        norm=norm,
+    )(x)
+    segnn = hk.without_apply_rng(hk.transform_with_state(segnn))
+
+    graph = rand_graph()
+    params, segnn_state = segnn.init(key, graph)
+
+    def wrapper(x):
+        st_graph = graph._replace(
+            graph=graph.graph._replace(nodes=x),
+            node_attributes=e3nn.spherical_harmonics("1x0e+1x1o", x, normalize=True),
+        )
+        y, _ = segnn.apply(params, segnn_state, st_graph)
+        return e3nn.IrrepsArray("1x1o", y)
+
+    assert_equivariant(wrapper, key, args_in=(e3nn.normal("1x1o", key, (5,)),))
+
+
+@pytest.mark.parametrize("task", ["graph", "node"])
+@pytest.mark.parametrize("norm", ["none", "instance"])
+def test_equivariance_legacy(key, rand_graph, norm, task):
+    import segnn_jax.config
+    segnn_jax.config.set_config("o3_layer", "legacy")
+
+    segnn = lambda x: SEGNN(
+        hidden_irreps=weight_balanced_irreps(8, e3nn.Irreps.spherical_harmonics(1)),
+        output_irreps=e3nn.Irreps("1x1o"),
+        num_layers=1,
+        task=task,
+        norm=norm,
+    )(x)
+    segnn = hk.without_apply_rng(hk.transform_with_state(segnn))
+
+    graph = rand_graph()
+    params, segnn_state = segnn.init(key, graph)
+
+    def wrapper(x):
+        st_graph = graph._replace(
+            graph=graph.graph._replace(nodes=x),
+            node_attributes=e3nn.spherical_harmonics("1x0e+1x1o", x, normalize=True),
+        )
+        y, _ = segnn.apply(params, segnn_state, st_graph)
+        return e3nn.IrrepsArray("1x1o", y)
+
+    assert_equivariant(wrapper, key, args_in=(e3nn.normal("1x1o", key, (5,)),))


### PR DESCRIPTION
- Updated tensor product, ~5-10% faster in training ([e3nn-jax 0.14.0](https://github.com/e3nn/e3nn-jax/tree/0.14.0)).
- Fixed a mistake on  __normalization parametrization__.
- Module refactor.
- Updated results.